### PR TITLE
Fix condition check for number of rows

### DIFF
--- a/lib/Astro/ADS/Result.pm
+++ b/lib/Astro/ADS/Result.pm
@@ -56,7 +56,7 @@ sub next {
         carp "No more results for ", $self->q, "\n";
         return;
     }
-    elsif ( $num && ! $num > 0 ) {
+    elsif ( $num && !($num > 0) ) {
         carp sprintf('Bad value for number of rows: %d. Defaulting to %d', $num, $self->rows);
         $num = 0;
     }


### PR DESCRIPTION
This trivial merge request fixes the following warning message:

Possible precedence problem between ! and numeric gt (>) at /wrkdirs/usr/ports/astro/p5-Astro-ADS/work/Astro-ADS-1.91/blib/lib/Astro/ADS/Result.pm line 59.

It partially addresses issue #33. 